### PR TITLE
Allow bypassing the `marked` compiler on description strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ use gulp to generate `react-doc.json` (react-doc infos with examples) and `react
 
 then see the example to config and create the doc pages.
 
+## Options
+
+### noMarkedDescription
+
+Pass `noMarkedDescription: true` to prevent running the `marked` compiler on `description` keys in the exported object. This is useful if you want to process the docs further yourself, for example building full markdown documentation pages.
 
 ## Change logs
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ function gulpPlugin(options = {}) {
         result[getModulePathByVinylFile(file)] = _.merge(
           descriptionProcess(moduleInfo, {
             basedir: path.dirname(file.path),
-            cwd: options.cwd
+            cwd: options.cwd,
+            noMarkedDescription: options.noMarkedDescription
           }),
           getModuleInfoByVinylFile(file)
         );

--- a/src/libs/__tests__/descriptionProcess.spec.js
+++ b/src/libs/__tests__/descriptionProcess.spec.js
@@ -68,6 +68,46 @@ describe(__filename, function () {
 
     });
 
+    it('should not process description in props if noMarkedDescription is set', function () {
+
+      let targetObj = {
+        'description': [
+          '# description.',
+          '@example console.log(1);'
+        ].join('\n'),
+        'props': {
+          'color': {
+            'description': [
+              '# description.',
+              '@example console.log(1);'
+            ].join('\n')
+          }
+        }
+      };
+
+      expect(descriptionProcess(targetObj, {
+        basedir: __dirname,
+        noMarkedDescription: true
+      }))
+        .to.to.deep.equal({
+          description: '# description.',
+          examples: [{
+            requireList: [],
+            contents: 'console.log(1);'
+          }],
+          props: {
+            'color': {
+              description: '# description.',
+              examples: [{
+                requireList: [],
+                contents: 'console.log(1);'
+              }]
+            }
+          }
+        });
+
+    });
+
   })
 
 });

--- a/src/libs/descriptionExtract.js
+++ b/src/libs/descriptionExtract.js
@@ -6,7 +6,7 @@ function descriptionExtract(descriptionString) {
     return null;
   }
   return doctrine.parse(descriptionString, {
-    unwrap: true,
+    // unwrap: true,
     sloppy: true,
     tags: [
       'example',

--- a/src/libs/descriptionProcess.js
+++ b/src/libs/descriptionProcess.js
@@ -11,7 +11,7 @@ function descriptionProcess(targetObj = {}, options = {}) {
   if (descObj) {
 
     descObj = {
-      description: marked(descObj.description),
+      description: options.noMarkedDescription ? descObj.description : marked(descObj.description),
       examples: pickExampleFromTags(descObj.tags, options)
     };
 


### PR DESCRIPTION
This is useful if you want to process the docs further yourself, for example building full markdown documentation pages.
