### PR TITLE
Show file path in error name when generate doc json

### DIFF
--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -100,4 +100,20 @@ describe(__filename, function () {
 
   });
 
+  context('error', ()=> {
+    beforeEach(()=> {
+      createComponentFile(`
+      export default {TYPE_A: 'A', TYPE_B: 'B'}
+      `);
+    });
+
+    it('when source file is not a component, should throw error with file path', done => {
+      gulpStartWithReactDocGenUI()
+        .on('error', (error) => {
+          expect(error.name).to.be.equal(`Error on handle file ${path.join(__dirname, '/Component.jsx')}`);
+          done();
+        })
+    });
+  });
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ function gulpPlugin(options = {}) {
       }
 
     } catch (err) {
+      err.name = `Error on handle file ${file.path}`;
       this.emit('error', new gUtil.PluginError(PLUGIN_NAME, err));
     }
 


### PR DESCRIPTION
Currently, when error happens on generate the JSON doc, the error won't show which file cause the error. It's very hard to track error, so I create this PR to show which file cause the error in Error name.
